### PR TITLE
fix typo about "正则表达式等价性的描述"

### DIFF
--- a/latex_src/the_awk_language.tex
+++ b/latex_src/the_awk_language.tex
@@ -616,7 +616,7 @@ Awk 不存在显式的拼接运算符. 如果 \textit{r}$_1$ 与 \textit{r}$_2$ 
 \begin{awkcode}
     $4 ~ /^(Asia|Europe)$/
 \end{awkcode}
-(如果两个正则表达式匹配了同一个字符串, 我们就说这两个正则表达式是
+(如果两个正则表达式匹配了相同的字符串集, 我们就说这两个正则表达式是
 \cterm{等价} (\term{equivalent}) 的. 测试一下读者对正则表达式优先级
 规则的理解程度, 下面这两个正则表达式等不等价: \verb'^Asia|Europe$' 与
 \verb'^(Asia|Europe)$' ?)


### PR DESCRIPTION
感谢您优秀的翻译工作！
这里有个翻译的小细节我觉得需要优化下：
"如果两个正则表达式匹配了**同一个字符串**, 我们就说这两个正则表达式是 等价 (equivalent) 的" -> "如果两个正则表达式匹配了**相同的字符串集**, 我们就说这两个正则表达式是 等价 (equivalent) 的"
因为：
1. 英文原文此处为 "Two regular expressions are equivalent if they match the same **strings**."，注意这里是 "string**s**"
2. 正则表达式匹配的不是一个字符串，而是一个字符串集合